### PR TITLE
https://github.com/gatling/gatling/issues/4194

### DIFF
--- a/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsIdleState.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/action/ws/fsm/WsIdleState.scala
@@ -16,16 +16,17 @@
 
 package io.gatling.http.action.ws.fsm
 
+import scala.concurrent.duration.DurationInt
+
 import io.gatling.commons.stats.OK
 import io.gatling.core.action.Action
 import io.gatling.core.session.Session
-import io.gatling.http.check.ws.{WsFrameCheck, WsFrameCheckSequence}
+import io.gatling.http.check.ws.{ WsFrameCheck, WsFrameCheckSequence }
 import io.gatling.http.client.WebSocket
+
 import com.typesafe.scalalogging.StrictLogging
 import io.netty.buffer.Unpooled
-import io.netty.handler.codec.http.websocketx.{BinaryWebSocketFrame, CloseWebSocketFrame, TextWebSocketFrame}
-
-import scala.concurrent.duration.DurationInt
+import io.netty.handler.codec.http.websocketx.{ BinaryWebSocketFrame, CloseWebSocketFrame, TextWebSocketFrame }
 
 final class WsIdleState(fsm: WsFsm, session: Session, webSocket: WebSocket, protected val remainingReconnects: Int) extends WsState(fsm) with StrictLogging {
 
@@ -132,7 +133,7 @@ final class WsIdleState(fsm: WsFsm, session: Session, webSocket: WebSocket, prot
 
   override def onClientCloseRequest(actionName: String, session: Session, next: Action): NextWsState = {
     logger.debug("Client requested WebSocket close")
-    scheduleTimeout(30.seconds) // TODO: from where should we get this value?
+    scheduleTimeout(httpProtocol.wsPart.clientCloseTimeout)
     webSocket.sendFrame(new CloseWebSocketFrame())
 
     NextWsState(new WsClosingState(fsm, actionName, session, next, clock.nowMillis))

--- a/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocol.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocol.scala
@@ -21,6 +21,8 @@ import java.net.InetAddress
 import java.util.regex.Pattern
 import javax.net.ssl.KeyManagerFactory
 
+import scala.concurrent.duration.{ DurationInt, FiniteDuration }
+
 import io.gatling.commons.validation.Validation
 import io.gatling.core.CoreComponents
 import io.gatling.core.config.GatlingConfiguration
@@ -108,7 +110,8 @@ object HttpProtocol extends StrictLogging {
       wsPart = HttpProtocolWsPart(
         wsBaseUrls = Nil,
         maxReconnects = 0,
-        autoReplyTextFrames = PartialFunction.empty
+        autoReplyTextFrames = PartialFunction.empty,
+        clientCloseTimeout = 30.seconds
       ),
       proxyPart = HttpProtocolProxyPart(
         proxy = None,
@@ -186,7 +189,8 @@ final case class HttpProtocolResponsePart(
 final case class HttpProtocolWsPart(
     wsBaseUrls: List[String],
     maxReconnects: Int,
-    autoReplyTextFrames: PartialFunction[String, String]
+    autoReplyTextFrames: PartialFunction[String, String],
+    clientCloseTimeout: FiniteDuration
 )
 
 final case class HttpProtocolProxyPart(

--- a/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocolBuilder.scala
+++ b/gatling-http/src/main/scala/io/gatling/http/protocol/HttpProtocolBuilder.scala
@@ -19,6 +19,7 @@ package io.gatling.http.protocol
 import java.net.{ Inet4Address, InetAddress, InetSocketAddress }
 import javax.net.ssl.KeyManagerFactory
 
+import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
 
 import io.gatling.commons.validation.Validation
@@ -200,6 +201,7 @@ final case class HttpProtocolBuilder(protocol: HttpProtocol, useOpenSsl: Boolean
   def wsAutoReplyTextFrame(f: PartialFunction[String, String]): HttpProtocolBuilder =
     this.modify(_.protocol.wsPart.autoReplyTextFrames).setTo(f)
   def wsAutoReplySocketIo4: HttpProtocolBuilder = wsAutoReplyTextFrame({ case "2" => "3" })
+  def wsClientCloseTimeout(timeout: FiniteDuration): HttpProtocolBuilder = this.modify(_.protocol.wsPart.clientCloseTimeout).setTo(timeout)
 
   // proxyPart
   def noProxyFor(hosts: String*): HttpProtocolBuilder = this.modify(_.protocol.proxyPart.proxyExceptions).setTo(hosts)


### PR DESCRIPTION
Client connect timeout configuration on HttpProtocol level.
Example:
  val httpProtocol = http
    .wsBaseUrl("ws://localhost:8080")
    .wsClientCloseTimeout(5.second)